### PR TITLE
Updated alert and alert payload classes

### DIFF
--- a/apns2/notification.py
+++ b/apns2/notification.py
@@ -15,7 +15,8 @@ class PayloadTooLargeError(Exception):
 class PayloadAlert(object):
     def __init__(
         self, body=None, action_loc_key=None, loc_key=None,
-        loc_args=None, launch_image=None, title=None,
+        loc_args=None, launch_image=None, title=None, title_loc_key=None,
+        title_loc_args=None
     ):
         super().__init__()
         self.body = body
@@ -24,6 +25,8 @@ class PayloadAlert(object):
         self.loc_key = loc_key
         self.loc_args = loc_args
         self.launch_image = launch_image
+        self.title_loc_key = title_loc_key
+        self.title_loc_args = title_loc_args
 
     def dict(self):
         d = {}
@@ -37,6 +40,11 @@ class PayloadAlert(object):
             d['loc-args'] = self.loc_args
         if self.launch_image:
             d['launch-image'] = self.launch_image
+        if self.title_loc_key:
+            d['title-loc-key'] = self.title_loc_key
+        if self.title_loc_args:
+            d['title-loc-args'] = self.title_loc_args
+
         return d
 
 

--- a/apns2/notification.py
+++ b/apns2/notification.py
@@ -43,14 +43,14 @@ class PayloadAlert(object):
 class Payload(object):
     def __init__(
         self, alert=None, badge=None, sound=None, category=None,
-        custom={}, content_available=False, mutable_content=False,
+        custom=None, content_available=False, mutable_content=False,
     ):
         super().__init__()
         self.alert = alert
         self.badge = badge
         self.sound = sound
         self.category = category
-        self.custom = custom
+        self.custom = custom or {}
         self.content_available = content_available
         self.mutable_content = mutable_content
 


### PR DESCRIPTION
Changes default value for `Payload`'s parameter `custom` to `None` and set it as an empty `dict` at runtime.

Adds `title_loc_key` and `title_loc_args` attributes to `PayloadAlert`.