### PR TITLE
Add proxy support

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -19,7 +19,7 @@ MODE_DEV = "dev"
 
 class APNSClient(object):
 
-    def __init__(self, mode: str, client_cert: str, password=None):
+    def __init__(self, mode: str, client_cert: str, password=None, proxy_host=None, proxy_port=None):
         if mode == MODE_PROD:
             self.host = "api.push.apple.com"
         elif mode == MODE_DEV:
@@ -32,6 +32,8 @@ class APNSClient(object):
             port=443,
             secure=True,
             ssl_context=init_context(cert=client_cert, cert_password=password),
+            proxy_host=proxy_host,
+            proxy_port=proxy_port,
         )
 
     def get_headers(self, n: Notification, topic: str = None):


### PR DESCRIPTION
`hyper` supports HTTP/2 proxies with TLS since this [commit](https://github.com/Lukasa/hyper/commit/185254bd22ace87f4e650f1bfe645c8a3f002c9f). This will expose proxy support in `apns2-client` too.